### PR TITLE
refactor: Update Base64 to match coding standard

### DIFF
--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -116,8 +116,7 @@ folly::dynamic ConstantTypedExpr::serialize() const {
     std::ostringstream out;
     saveVector(*valueVector_, out);
     auto serializedValue = out.str();
-    obj["valueVector"] = encoding::Base64::encode(
-        serializedValue.data(), serializedValue.size());
+    obj["valueVector"] = encoding::Base64::encode(serializedValue);
   } else {
     obj["value"] = value_.serialize();
   }

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -762,8 +762,7 @@ folly::dynamic ValuesNode::serialize() const {
 
   auto serializedData = out.str();
 
-  obj["data"] =
-      encoding::Base64::encode(serializedData.data(), serializedData.size());
+  obj["data"] = encoding::Base64::encode(serializedData);
   obj["parallelizable"] = parallelizable_;
   obj["repeatTimes"] = repeatTimes_;
   return obj;

--- a/velox/dwio/text/reader/TextReader.cpp
+++ b/velox/dwio/text/reader/TextReader.cpp
@@ -1104,19 +1104,14 @@ void TextRowReader::readElement(
         return;
       }
 
-      // Allocate a blob buffer
-      size_t len = str.size();
-      const auto blen = encoding::Base64::calculateDecodedSize(str.data(), len);
-      varBinBuf_->resize(blen.value_or(0));
-
-      // decode from base64 to the blob buffer.
-      Status status = encoding::Base64::decode(
-          str.data(), str.size(), varBinBuf_->data(), blen.value_or(0));
+      // Decode from base64 to the blob buffer in one call.
+      std::string decodedStr;
+      Status status = encoding::Base64::decode(str, decodedStr);
 
       if (status.code() == StatusCode::kOK) {
-        flatVector->set(
-            insertionRow,
-            StringView(varBinBuf_->data(), static_cast<int32_t>(blen.value())));
+        varBinBuf_->resize(decodedStr.size());
+        std::memcpy(varBinBuf_->data(), decodedStr.data(), decodedStr.size());
+        flatVector->set(insertionRow, StringView(decodedStr));
       } else {
         // Not valid base64:  just copy as-is for compatibility.
         //
@@ -1128,16 +1123,12 @@ void TextRowReader::readElement(
         varBinBuf_->resize(str.size());
 
         VELOX_CHECK_NOT_NULL(str.data());
-
-        len = str.size();
         memcpy(varBinBuf_->data(), str.data(), str.size());
 
         // Use StringView, set(vector_size_t idx, T value) fails because
         // strlen(varBinBuf_->data()) is undefined due to lack of null
         // terminator
-        flatVector->set(
-            insertionRow,
-            StringView(varBinBuf_->data(), static_cast<int32_t>(str.size())));
+        flatVector->set(insertionRow, StringView(str));
       }
 
       if (isNull) {

--- a/velox/dwio/text/writer/TextWriter.cpp
+++ b/velox/dwio/text/writer/TextWriter.cpp
@@ -249,8 +249,9 @@ void TextWriter::writeCellValue(
     }
     case TypeKind::VARBINARY: {
       auto data = decodedColumnVector->valueAt<StringView>(row);
-      dataStr =
-          std::optional(encoding::Base64::encode(data.data(), data.size()));
+      dataStr = std::optional(
+          encoding::Base64::encode(
+              std::string_view(data.data(), data.size()), true));
       break;
     }
     case TypeKind::ARRAY: {

--- a/velox/functions/sparksql/Base64Function.h
+++ b/velox/functions/sparksql/Base64Function.h
@@ -30,7 +30,10 @@ struct Base64Function {
       out_type<Varchar>& result,
       const arg_type<Varbinary>& input) {
     result.resize(encoding::Base64::calculateMimeEncodedSize(input.size()));
-    encoding::Base64::encodeMime(input.data(), input.size(), result.data());
+    std::string encodedStr;
+    encoding::Base64::encodeMime(
+        std::string_view(input.data(), input.size()), encodedStr);
+    std::memcpy(result.data(), encodedStr.data(), encodedStr.size());
   }
 };
 } // namespace facebook::velox::functions::sparksql


### PR DESCRIPTION
## Summary by Sourcery

Refactor Base64 encoding/decoding APIs to use std::string_view and std::string-based interfaces and update all callers accordingly.

Enhancements:
- Simplify Base64 and Base64 URL encode/decode APIs to operate on std::string_view inputs and std::string outputs instead of raw pointer/size buffers and pairs.
- Unify Base64 decoded-size and MIME decoded-size helpers to string_view-based signatures and internal size management, improving safety and clarity.
- Adjust PrestoSQL and SparkSQL Base64/UnBase64 functions, text reader/writer, and plan/expr serialization code to use the updated Base64 interfaces.
- Update Base64 unit tests to match the new string_view-based APIs and validation behavior for padding and MIME decoding.